### PR TITLE
standardizing the coding conventions to the rest of the repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/python/black/
+    rev: 19.10b0
+    hooks:
+    -   id: black
+
+-   repo: https://github.com/sqlalchemyorg/zimports/
+    rev: master
+    hooks:
+    -   id: zimports
+
+-   repo: https://github.com/pycqa/flake8
+    rev: master
+    hooks:
+    -   id: flake8
+        additional_dependencies:
+          - flake8-import-order
+          - flake8-builtins
+          - flake8-docstrings
+          - flake8-rst-docstrings
+          - pydocstyle<4.0.0
+          - pygments

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 sqlalchemy-access
 =================
 
+.. image:: https://img.shields.io/pypi/dm/sqlalchemy-access.svg
+        :target: https://pypi.org/project/sqlalchemy-access/
+
 A Microsoft Access dialect for SQLAlchemy.
 
 Objectives

--- a/README.rst
+++ b/README.rst
@@ -48,3 +48,30 @@ For other ways of connecting see the `Getting Connected`_ page in the Wiki.
 .. _ODBC DSN (Data Source Name): https://support.microsoft.com/en-ca/help/966849/what-is-a-dsn-data-source-name
 .. _ExtendedAnsiSQL: https://github.com/sqlalchemy/sqlalchemy-access/wiki/%5Btip%5D-use-ExtendedAnsiSQL
 .. _Getting Connected: https://github.com/sqlalchemy/sqlalchemy-access/wiki/Getting-Connected
+
+The SQLAlchemy Project
+======================
+
+SQLAlchemy-access is part of the `SQLAlchemy Project <https://www.sqlalchemy.org>`_ and
+adheres to the same standards and conventions as the core project.
+
+Development / Bug reporting / Pull requests
+___________________________________________
+
+Please refer to the
+`SQLAlchemy Community Guide <https://www.sqlalchemy.org/develop.html>`_ for
+guidelines on coding and participating in this project.
+
+Code of Conduct
+_______________
+
+Above all, SQLAlchemy places great emphasis on polite, thoughtful, and
+constructive communication between users and developers.
+Please see our current Code of Conduct at
+`Code of Conduct <https://www.sqlalchemy.org/codeofconduct.html>`_.
+
+License
+=======
+
+SQLAlchemy-access is distributed under the `MIT license
+<https://opensource.org/licenses/MIT>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+target-version = ['py27']

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,18 @@ profile_file=test/profiles.txt
 [db]
 default=access+pyodbc://admin@access_test
 sqlite=sqlite:///:memory:
+
+[flake8]
+show-source = true
+enable-extensions = G
+# E203 is due to https://github.com/PyCQA/pycodestyle/issues/373
+ignore =
+    A003,
+    D,
+    E203,E305,E711,E712,E721,E722,E741,
+    N801,N802,N806,
+    RST304,RST303,RST299,RST399,
+    W503,W504
+exclude = .venv,.git,.tox,dist,doc,*egg,build
+import-order-style = google
+application-import-names = sqlalchemy_access

--- a/setup.py
+++ b/setup.py
@@ -3,44 +3,47 @@ import re
 
 from setuptools import setup, find_packages
 
-v = open(os.path.join(os.path.dirname(__file__), 'sqlalchemy_access', '__init__.py'))
-VERSION = re.compile(r".*__version__ = '(.*?)'", re.S).match(v.read()).group(1)
+v = open(
+    os.path.join(os.path.dirname(__file__), "sqlalchemy_access", "__init__.py")
+)
+VERSION = re.compile(r'.*__version__ = "(.*?)"', re.S).match(v.read()).group(1)
 v.close()
 
-readme = os.path.join(os.path.dirname(__file__), 'README.rst')
+readme = os.path.join(os.path.dirname(__file__), "README.rst")
 
 
-setup(name='sqlalchemy-access',
-      version=VERSION,
-      description="MS Access for SQLAlchemy",
-      long_description=open(readme).read(),
-      url='https://github.com/sqlalchemy/sqlalchemy-access',
-      author='Gord Thompson',
-      author_email='gord@gordthompson.com',
-      license='MIT',
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Topic :: Database :: Front-Ends',
-          'Operating System :: OS Independent',
-      ],
-      keywords='SQLAlchemy Microsoft Access',
-      project_urls={
-          'Documentation': 'https://github.com/sqlalchemy/sqlalchemy-access/wiki',
-          'Source': 'https://github.com/sqlalchemy/sqlalchemy-access',
-          'Tracker': 'https://github.com/sqlalchemy/sqlalchemy-access/issues',
-      },
-      packages=find_packages(include=['sqlalchemy_access']),
-      include_package_data=True,
-      install_requires = ['SQLAlchemy', 'pyodbc>=4.0.27'],
-      zip_safe=False,
-      entry_points={
-          'sqlalchemy.dialects': [
-              'access.pyodbc = sqlalchemy_access.pyodbc:AccessDialect_pyodbc',
-          ]
-      },
+setup(
+    name="sqlalchemy-access",
+    version=VERSION,
+    description="MS Access for SQLAlchemy",
+    long_description=open(readme).read(),
+    url="https://github.com/sqlalchemy/sqlalchemy-access",
+    author="Gord Thompson",
+    author_email="gord@gordthompson.com",
+    license="MIT",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Database :: Front-Ends",
+        "Operating System :: OS Independent",
+    ],
+    keywords="SQLAlchemy Microsoft Access",
+    project_urls={
+        "Documentation": "https://github.com/sqlalchemy/sqlalchemy-access/wiki",
+        "Source": "https://github.com/sqlalchemy/sqlalchemy-access",
+        "Tracker": "https://github.com/sqlalchemy/sqlalchemy-access/issues",
+    },
+    packages=find_packages(include=["sqlalchemy_access"]),
+    include_package_data=True,
+    install_requires=["SQLAlchemy", "pyodbc>=4.0.27"],
+    zip_safe=False,
+    entry_points={
+        "sqlalchemy.dialects": [
+            "access.pyodbc = sqlalchemy_access.pyodbc:AccessDialect_pyodbc",
+        ]
+    },
 )

--- a/sqlalchemy_access/__init__.py
+++ b/sqlalchemy_access/__init__.py
@@ -1,11 +1,28 @@
 from sqlalchemy.dialects import registry as _registry
 
-from .base import AutoNumber, Byte, Char, Currency, DateTime, Decimal, Double, Integer, LongInteger, \
-        LongText, OleObject, ReplicationID, ShortText, Single, YesNo
+from .base import (
+    AutoNumber,
+    Byte,
+    Char,
+    Currency,
+    DateTime,
+    Decimal,
+    Double,
+    Integer,
+    LongInteger,
+    LongText,
+    OleObject,
+    ReplicationID,
+    ShortText,
+    Single,
+    YesNo,
+)
 
 import pyodbc
 
-__version__ = '1.0.3'
+__version__ = "1.0.3"
 
 pyodbc.pooling = False  # required for Access databases with ODBC linked tables
-_registry.register("access.pyodbc", "sqlalchemy_access.pyodbc", "AccessDialect_pyodbc")
+_registry.register(
+    "access.pyodbc", "sqlalchemy_access.pyodbc", "AccessDialect_pyodbc"
+)

--- a/sqlalchemy_access/pyodbc.py
+++ b/sqlalchemy_access/pyodbc.py
@@ -26,6 +26,7 @@ from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from sqlalchemy import types as sqltypes, util
 import decimal
 
+
 class _AccessNumeric_pyodbc(sqltypes.Numeric):
     """Turns Decimals with adjusted() < 0 or > 7 into strings.
 
@@ -36,15 +37,15 @@ class _AccessNumeric_pyodbc(sqltypes.Numeric):
 
     def bind_processor(self, dialect):
 
-        super_process = super(_AccessNumeric_pyodbc, self).\
-                        bind_processor(dialect)
+        super_process = super(_AccessNumeric_pyodbc, self).bind_processor(
+            dialect
+        )
 
         if not dialect._need_decimal_fix:
             return super_process
 
         def process(value):
-            if self.asdecimal and \
-                    isinstance(value, decimal.Decimal):
+            if self.asdecimal and isinstance(value, decimal.Decimal):
 
                 adjusted = value.adjusted()
                 if adjusted < 0:
@@ -56,6 +57,7 @@ class _AccessNumeric_pyodbc(sqltypes.Numeric):
                 return super_process(value)
             else:
                 return value
+
         return process
 
     # these routines needed for older versions of pyodbc.
@@ -63,30 +65,31 @@ class _AccessNumeric_pyodbc(sqltypes.Numeric):
 
     def _small_dec_to_string(self, value):
         return "%s0.%s%s" % (
-                    (value < 0 and '-' or ''),
-                    '0' * (abs(value.adjusted()) - 1),
-                    "".join([str(nint) for nint in value.as_tuple()[1]]))
+            (value < 0 and "-" or ""),
+            "0" * (abs(value.adjusted()) - 1),
+            "".join([str(nint) for nint in value.as_tuple()[1]]),
+        )
 
     def _large_dec_to_string(self, value):
         _int = value.as_tuple()[1]
-        if 'E' in str(value):
+        if "E" in str(value):
             result = "%s%s%s" % (
-                    (value < 0 and '-' or ''),
-                    "".join([str(s) for s in _int]),
-                    "0" * (value.adjusted() - (len(_int)-1)))
+                (value < 0 and "-" or ""),
+                "".join([str(s) for s in _int]),
+                "0" * (value.adjusted() - (len(_int) - 1)),
+            )
         else:
             if (len(_int) - 1) > value.adjusted():
                 result = "%s%s.%s" % (
-                (value < 0 and '-' or ''),
-                "".join(
-                    [str(s) for s in _int][0:value.adjusted() + 1]),
-                "".join(
-                    [str(s) for s in _int][value.adjusted() + 1:]))
+                    (value < 0 and "-" or ""),
+                    "".join([str(s) for s in _int][0 : value.adjusted() + 1]),
+                    "".join([str(s) for s in _int][value.adjusted() + 1 :]),
+                )
             else:
                 result = "%s%s" % (
-                (value < 0 and '-' or ''),
-                "".join(
-                    [str(s) for s in _int][0:value.adjusted() + 1]))
+                    (value < 0 and "-" or ""),
+                    "".join([str(s) for s in _int][0 : value.adjusted() + 1]),
+                )
         return result
 
 
@@ -98,12 +101,8 @@ class AccessDialect_pyodbc(PyODBCConnector, AccessDialect):
 
     execution_ctx_cls = AccessExecutionContext_pyodbc
 
-    pyodbc_driver_name = 'Microsoft Access'
+    pyodbc_driver_name = "Microsoft Access"
 
     colspecs = util.update_copy(
-        AccessDialect.colspecs,
-        {
-            sqltypes.Numeric:_AccessNumeric_pyodbc
-        }
+        AccessDialect.colspecs, {sqltypes.Numeric: _AccessNumeric_pyodbc}
     )
-

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,9 @@
 from sqlalchemy.dialects import registry
 import pytest
 
-registry.register("access.pyodbc", "sqlalchemy_access.pyodbc", "AccessDialect_pyodbc")
+registry.register(
+    "access.pyodbc", "sqlalchemy_access.pyodbc", "AccessDialect_pyodbc"
+)
 
 pytest.register_assert_rewrite("sqlalchemy.testing.assertions")
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1,7 +1,11 @@
 from sqlalchemy.testing.suite import *
 
-from sqlalchemy.testing.suite import ComponentReflectionTest as _ComponentReflectionTest
-from sqlalchemy.testing.suite import ExpandingBoundInTest as _ExpandingBoundInTest
+from sqlalchemy.testing.suite import (
+    ComponentReflectionTest as _ComponentReflectionTest,
+)
+from sqlalchemy.testing.suite import (
+    ExpandingBoundInTest as _ExpandingBoundInTest,
+)
 from sqlalchemy.testing.suite import InsertBehaviorTest as _InsertBehaviorTest
 from sqlalchemy.testing.suite import IntegerTest as _IntegerTest
 from sqlalchemy.testing.suite import LikeFunctionsTest as _LikeFunctionsTest
@@ -26,6 +30,7 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     def test_nullable_reflection(cls):
         # Access ODBC implementation of the SQLColumns function reports that a column is nullable even when it is not
         return
+
 
 class ExpandingBoundInTest(_ExpandingBoundInTest):
     @classmethod

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -3,11 +3,13 @@ from sqlalchemy.testing.suite import *
 from sqlalchemy.testing.suite import (
     ComponentReflectionTest as _ComponentReflectionTest,
 )
+from sqlalchemy.testing.suite import DateTimeTest as _DateTimeTest
 from sqlalchemy.testing.suite import (
     ExpandingBoundInTest as _ExpandingBoundInTest,
 )
 from sqlalchemy.testing.suite import InsertBehaviorTest as _InsertBehaviorTest
 from sqlalchemy.testing.suite import IntegerTest as _IntegerTest
+from sqlalchemy.testing.suite import JoinTest as _JoinTest
 from sqlalchemy.testing.suite import LikeFunctionsTest as _LikeFunctionsTest
 from sqlalchemy.testing.suite import NumericTest as _NumericTest
 from sqlalchemy.testing.suite import OrderByLabelTest as _OrderByLabelTest
@@ -17,8 +19,9 @@ from sqlalchemy.testing.suite import TableDDLTest as _TableDDLTest
 class ComponentReflectionTest(_ComponentReflectionTest):
     @classmethod
     def test_get_noncol_index_pk(cls):
-        # This test fails because Access automatically creates a unique *index* (not constraint) on the primary key.
-        # The test is expecting to see just one index (on a non-PK column) but it is seeing two.
+        # This test fails because Access automatically creates a unique
+        # *index* (not constraint) on the primary key. The test is expecting
+        # to see just one index (on a non-PK column) but it is seeing two.
         return
 
     @classmethod
@@ -28,14 +31,25 @@ class ComponentReflectionTest(_ComponentReflectionTest):
 
     @classmethod
     def test_nullable_reflection(cls):
-        # Access ODBC implementation of the SQLColumns function reports that a column is nullable even when it is not
+        # Access ODBC implementation of the SQLColumns function reports that
+        # a column is nullable even when it is not
+        return
+
+
+class DateTimeTest(_DateTimeTest):
+    @classmethod
+    def test_null_bound_comparison(cls):
+        # bypass this test because Access ODBC fails with
+        # "Unrecognized keyword WHEN."
         return
 
 
 class ExpandingBoundInTest(_ExpandingBoundInTest):
     @classmethod
     def test_null_in_empty_set_is_false(cls):
-        """ Access SQL can't do CASE ... WHEN, but this test would pass if we re-wrote the query to be
+        """ Access SQL can't do CASE ... WHEN, but this test would pass if we
+            re-wrote the query to be
+
                 SELECT (n = 1) AS result
                 FROM
                     (
@@ -58,7 +72,27 @@ class IntegerTest(_IntegerTest):
     @classmethod
     def test_huge_int(cls):
         # bypass this test because Access ODBC fails with
-        # [ODBC Microsoft Access Driver]Optional feature not implemented.
+        # [ODBC Microsoft Access Driver] Optional feature not implemented.
+        return
+
+
+class JoinTest(_JoinTest):
+    @classmethod
+    def test_inner_join_true(cls):
+        # bypass this test because Access ODBC fails with
+        # "JOIN expression not supported."
+        return
+
+    @classmethod
+    def test_inner_join_false(cls):
+        # bypass this test because Access ODBC fails with
+        # "JOIN expression not supported."
+        return
+
+    @classmethod
+    def test_outer_join_false(cls):
+        # bypass this test because Access ODBC fails with
+        # "JOIN expression not supported."
         return
 
 
@@ -104,13 +138,15 @@ class LikeFunctionsTest(_LikeFunctionsTest):
 class NumericTest(_NumericTest):
     @classmethod
     def test_decimal_coerce_round_trip(cls):
-        # bug in Access SQL: "SELECT ? AS anon_1 ..." returns rubbish with a decimal.Decimal parameter value
+        # bug in Access SQL: "SELECT ? AS anon_1 ..." returns rubbish with a
+        # decimal.Decimal parameter value
         # https://github.com/mkleehammer/pyodbc/issues/624
         return
 
     @classmethod
     def test_decimal_coerce_round_trip_w_cast(cls):
-        # bug in Access SQL: "SELECT ? AS anon_1 ..." returns rubbish with a decimal.Decimal parameter value
+        # bug in Access SQL: "SELECT ? AS anon_1 ..." returns rubbish with a
+        # decimal.Decimal parameter value
         # https://github.com/mkleehammer/pyodbc/issues/624
         return
 
@@ -119,7 +155,7 @@ class OrderByLabelTest(_OrderByLabelTest):
     @classmethod
     def test_composed_multiple(cls):
         # SELECT statement too complex for Access SQL
-        # [ODBC Microsoft Access Driver] Reserved error (-1001); there is no message for this error.
+        # "Reserved error (-1001); there is no message for this error."
         return
 
 


### PR DESCRIPTION
This is the last repo in my housekeeping push to standardize the coding conventions and developer guidelines across the 'sqlalchemy' orgs various libraries.

**This is not tested, as I don't have access to ms access**

This is unfortunately also the biggest changeset, as it did not already use `black` or pre-commit, so this absolutely needs a review.