### PR TITLE
Use the same connection instead of a new one for database reflection.

### DIFF
--- a/sqlalchemy_access/base.py
+++ b/sqlalchemy_access/base.py
@@ -693,13 +693,13 @@ class AccessDialect(default.DefaultDialect):
         return self.context.last_inserted_ids
 
     def has_table(self, connection, tablename, schema=None):
-        pyodbc_crsr = connection.engine.raw_connection().cursor()
+        pyodbc_crsr = connection.connection.cursor()
         result = pyodbc_crsr.tables(table=tablename).fetchone()
         return bool(result)
 
     @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
-        pyodbc_crsr = connection.engine.raw_connection().cursor()
+        pyodbc_crsr = connection.connection.cursor()
         result = pyodbc_crsr.tables(tableType="TABLE").fetchall()
         table_names = [
             row.table_name
@@ -713,7 +713,7 @@ class AccessDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_view_names(self, connection, schema=None, **kw):
-        pyodbc_crsr = connection.engine.raw_connection().cursor()
+        pyodbc_crsr = connection.connection.cursor()
         result = pyodbc_crsr.tables(tableType="VIEW").fetchall()
         return [row[2] for row in result]
 
@@ -730,7 +730,7 @@ class AccessDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
-        pyodbc_cnxn = connection.engine.raw_connection()
+        pyodbc_cnxn = connection.connection
         # work around bug in Access ODBC driver
         # ref: https://github.com/mkleehammer/pyodbc/issues/328
         prev_converter = pyodbc_cnxn.get_output_converter(pyodbc.SQL_WVARCHAR)
@@ -774,7 +774,7 @@ class AccessDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
-        pyodbc_crsr = connection.engine.raw_connection().cursor()
+        pyodbc_crsr = connection.connection.cursor()
         db_path = pyodbc_crsr.tables(table=table_name).fetchval()
         if db_path:
             db_engine = win32com.client.Dispatch(
@@ -802,7 +802,7 @@ class AccessDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):
-        pyodbc_crsr = connection.engine.raw_connection().cursor()
+        pyodbc_crsr = connection.connection.cursor()
         db_path = pyodbc_crsr.tables(table=table_name).fetchval()
         if db_path:
             db_engine = win32com.client.Dispatch(
@@ -836,7 +836,7 @@ class AccessDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_indexes(self, connection, table_name, schema=None, **kw):
-        pyodbc_crsr = connection.engine.raw_connection().cursor()
+        pyodbc_crsr = connection.connection.cursor()
         indexes = {}
         for row in pyodbc_crsr.statistics(table_name).fetchall():
             if row.index_name is not None:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -112,6 +112,10 @@ class ExpandingBoundInTest(_ExpandingBoundInTest):
         return
 
     @testing.skip("access")
+    def test_null_in_empty_set_is_false(self):
+        return
+
+    @testing.skip("access")
     def test_empty_set_against_integer_bindparam(self):
         return
 


### PR DESCRIPTION
When I pass poolclass=sqlalchemy.pool.NullPool to create_engine, and then create a sqlalchemy.Table object from an Access database, python crashes.  When I replace NullPool with StaticPool, it works fine, but I wonder if you could accept this pull request so that I can use NullPool instead.

The tests seem to work, but four tests fail when I run them all together, both before and after the changes in this PR.  If I run the four tests individually pass.  Here are the error summaries when I run them all together:

FAILED test/test_suite.py::ComponentReflectionTest_access+pyodbc_12_0_0::test_get_foreign_keys[False-_exclusions0] - pywintypes.com_error: (-2146825203, 'OLE error 0...
FAILED test/test_suite.py::ComponentReflectionTest_access+pyodbc_12_0_0::test_get_table_names[foreign_key-True-False-False-_exclusions2] - pywintypes.com_error: (-21...
FAILED test/test_suite.py::CompositeKeyReflectionTest_access+pyodbc_12_0_0::test_fk_column_order - pywintypes.com_error: (-2146825203, 'OLE error 0x800a0c0d', None, ...
FAILED test/test_suite.py::CompositeKeyReflectionTest_access+pyodbc_12_0_0::test_pk_column_order - pywintypes.com_error: (-2147352567, 'Exception occurred.', (0, 'DA...