### PR TITLE
Fix base.py for Access DB 2010

### DIFF
--- a/sqlalchemy_access/base.py
+++ b/sqlalchemy_access/base.py
@@ -283,7 +283,10 @@ class AccessTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_BOOLEAN(self, type_, **kw):
         return YESNO.__visit_name__
-
+    
+    def visit_YESNO(self, type_, **kw):
+        return YESNO.__visit_name__
+    
     def visit_COUNTER(self, type_, **kw):
         return COUNTER.__visit_name__
 


### PR DESCRIPTION
fix error :  AttributeError: 'AccessTypeCompiler' object has no attribute 'visit_YESNO'. Did you mean: 'visit_REAL'?